### PR TITLE
linux-server-chart: remove fixed volume mounts

### DIFF
--- a/apps/media/jackett/values.yaml
+++ b/apps/media/jackett/values.yaml
@@ -12,5 +12,9 @@ linux-server-base:
       cpu: 0.5
       memory: 300Mi
   extraVolumes:
-    movies: longhorn-jellyfin-movies-pvc
-    downloads: longhorn-downloads-2-pvc
+  - name: movies
+    claim: longhorn-jellyfin-movies-pvc
+    path: /data/movies
+  - name: downloads
+    claim: longhorn-downloads-2-pvc
+    path: /downloads

--- a/apps/media/radarr/values.yaml
+++ b/apps/media/radarr/values.yaml
@@ -12,5 +12,9 @@ linux-server-base:
       cpu: 0.5
       memory: 300Mi
   extraVolumes:
-    movies: longhorn-jellyfin-movies-pvc
-    downloads: longhorn-downloads-2-pvc
+  - name: movies
+    claim: longhorn-jellyfin-movies-pvc
+    path: /data/movies
+  - name: downloads
+    claim: longhorn-downloads-2-pvc
+    path: /downloads

--- a/charts/linux-server-base/templates/statefulset.yaml
+++ b/charts/linux-server-base/templates/statefulset.yaml
@@ -22,18 +22,18 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /config
-        - name: movies
-          mountPath: /data/movies
-        - name: downloads
-          mountPath: /downloads
+{{- range $vol := .Values.extraVolumes }}
+        - name: {{ $vol.name }}
+          mountPath: {{ $vol.path }}
+{{- end }}
         resources:
 {{ .Values.resources | toYaml | indent 10 }}
       volumes:
         - name: config
           persistentVolumeClaim:
             claimName: longhorn-{{ .Values.name }}-config-pvc
-{{- range $name, $vol := .Values.extraVolumes }}
-        - name: {{ $name }}
+{{- range $vol := .Values.extraVolumes }}
+        - name: {{ $vol.name }}
           persistentVolumeClaim:
-            claimName: {{ $vol }}
+            claimName: {{ $vol.claim }}
 {{- end }}

--- a/charts/linux-server-base/values.yaml
+++ b/charts/linux-server-base/values.yaml
@@ -11,5 +11,3 @@ resources:
     cpu: 0.5
     memory: 300Mi
 extraVolumes:
-  # movies: longhorn-jellyfin-movies-pvc
-  # downloads: longhorn-downloads-2-pvc


### PR DESCRIPTION
/data/movies and /downloads were fixed, but most images don't need this